### PR TITLE
changes in 'rigor' and compute_best_recall_candidates

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ i. load groundtruth.
 > testset=load('evaluation-metrics/data/pascal_gt_data.mat');
 
 ii. generate best recall candidates
-> compute_best_recall_candidates(testset,configjson);
+> compute_best_recall_candidates(testset,configjson,'< proposalName >');
+'proposalName' is an optional argument. If not provided, the function works for all the object proposals listed above. 
 
 iii. plot RECALL/AUC curves.
 > evaluateMetricForProposal('RECALL','< proposalName>');

--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ In steps (ii) and (iii) < proposalname > is the object proposal you want to run.
 
 Note:
         RIGOR requires boost and tbb libraries. Please follow the instruction at https://docs.google.com/document/d/19hEkfpPsRYnYHBBmWxI-EMFPkkO-fhhDx8Js4HFrKv8 to setup these libraries.
-        RIGOR does not support .mat as argument for calcrigorForIm function. It only accepts the image path.
 
 Evaluating proposals:
 =====================

--- a/config.json
+++ b/config.json
@@ -89,7 +89,7 @@
 	"selective_search" : {
 		"opts" : {
 				"isBaseline" : false,
-				"order": "ascend"
+				"order": "random"
 			},
 			"params": {
 				"ks" :[50, 100],

--- a/evaluation-metrics/aboEvaluation/compute_abo_candidates.m
+++ b/evaluation-metrics/aboEvaluation/compute_abo_candidates.m
@@ -1,4 +1,4 @@
-function compute_abo_candidates(testset, config)
+function compute_abo_candidates(testset, config, varargin)
 
 num_images = numel(testset.impos);
 candidates_thresholds = round(10 .^ (0:0.5:4))
@@ -7,9 +7,18 @@ num_candidates_thresholds = numel(candidates_thresholds);
 proposalNames = fieldnames(config);
 proposalsToEvaluate=proposalNames(3:end-1);
 
+if length(varargin) == 1
+      if ischar(varargin{1})
+          proposalsToEvaluate = proposalsToEvaluate(strcmp(proposalsToEvaluate,varargin{1}));
+      else
+          display('Input proposal as string')
+          return;
+      end
+end
+
 for i = 1:length(proposalsToEvaluate)
 	method = config.(char(proposalsToEvaluate{i}));
-	candidate_dir=[config.outputLocation proposalsToEvaluate{i}];
+	candidate_dir=[config.outputLocation '/' proposalsToEvaluate{i}];
 	fileName=[ candidate_dir '/' 'abo_candidates.mat']; 
     try
 	method=config.(char(proposalsToEvaluate(i)))

--- a/evaluation-metrics/aboEvaluation/evaluateABO.m
+++ b/evaluation-metrics/aboEvaluation/evaluateABO.m
@@ -9,7 +9,8 @@ function evaluateABO( config,outputLocation)
   figure;
   for i = 1:n
       try
-        data = load(char(fullfile(config.(char(proposalNames(i))).opts.outputLocation, aboFileName)));
+        %data = load(char(fullfile(config.(char(proposalNames(i))).opts.outputLocation, aboFileName)));
+        data = load([ num2str(cell2mat(config.(char(proposalNames(i))).opts.outputLocation)) '/' aboFileName]);
  	count=count+1;
         num_experiments = numel(data.abo_candidates);
         x = zeros(num_experiments, 1);

--- a/evaluation-metrics/recall/compute_best_recall_candidates.m
+++ b/evaluation-metrics/recall/compute_best_recall_candidates.m
@@ -17,7 +17,7 @@ function compute_best_recall_candidates(testset, config,varargin)
   
   for i = 1:length(proposalsToEvaluate)
   	method = config.(char(proposalsToEvaluate{i}));
-	candidate_dir=[config.outputLocation proposalsToEvaluate{i}];
+	candidate_dir=[config.outputLocation '/' proposalsToEvaluate{i}];
 	fileName=[candidate_dir '/' 'best_recall_candidates.mat']
     	try
    		method=config.(char(proposalsToEvaluate(i)))

--- a/evaluation-metrics/recall/evaluateAUC.m
+++ b/evaluation-metrics/recall/evaluateAUC.m
@@ -9,7 +9,8 @@ function evaluateAUC( methods, outputLocation)
   figure;
   for i = 1:n
       try
-        data = load(char(fullfile(methods.(char(proposalNames(i))).opts.outputLocation, bestRecallFileName)));
+        %data = load(char(fullfile(methods.(char(proposalNames(i))).opts.outputLocation, bestRecallFileName)));
+        data = load([ num2str(cell2mat(methods.(char(proposalNames(i))).opts.outputLocation)) '/' bestRecallFileName]);
         count=count+1;
 	num_experiments = numel(data.best_candidates);
         x = zeros(num_experiments, 1);

--- a/evaluation-metrics/recall/evaluateRECALL.m
+++ b/evaluation-metrics/recall/evaluateRECALL.m
@@ -20,7 +20,8 @@ function evaluateRECALL(methods, outputLocation,varargin)
   count = 0;
   for i = 1:n
       try
-        data = load(char(fullfile(methods.(char(proposalNames(i))).opts.outputLocation, bestRecallFileName)));
+        %data = load(char(fullfile(methods.(char(proposalNames(i))).opts.outputLocation, bestRecallFileName)));
+        data = load([ num2str(cell2mat(methods.(char(proposalNames(i))).opts.outputLocation)) '/' bestRecallFileName]);
     	count=count+1;
         thresh_idx = find( ...
           [data.best_candidates.candidates_threshold] <= num_candidates, 1, 'last');

--- a/rigor/rigor_src/rigor_obj_segments.m
+++ b/rigor/rigor_src/rigor_obj_segments.m
@@ -182,8 +182,16 @@ function [masks, seg_obj, total_time] = rigor_obj_segments(img_filepath, ...
                     extra_params);
     
     % read im
-    input_info.img_filepath = img_filepath;
-    I = imread(img_filepath);
+    if ischar(img_filepath)
+        input_info.img_filepath = img_filepath;
+        I = imread(img_filepath);
+    else
+        % copy image onto I from img_filepath
+        I = img_filepath;
+        % set random default img_filepath with random image name! 
+        img_filepath = 'mypath/myimage';
+        input_info.img_filepath = img_filepath; 
+    end
     
     % initialize the Segmenter (include paths, init data-structures,
     % preload data, start threads ...)


### PR DESCRIPTION
1. rigor: can now take 'im.mat' arguments unlike before where only a 'path/to/img' was accepted.
2. compute_best_recall_candidates.m can take an additional argument for < 'proposalName' > and so, there is no need to run all object-proposals. 
3. evaluateAUC/RECALL: change in cell2str for reading data. (alternate method as conversion to char is not compatible with older matlab versions )
4. README changed to include above changes. 